### PR TITLE
Add NET_RAW capability

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -66,6 +66,7 @@ securityContext:
   capabilities:
     add:
     - NET_ADMIN
+    - NET_RAW
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
 


### PR DESCRIPTION
Host OS:

```
$ uname -a
Linux pi4a-k8s 5.8.0-1010-raspi #13-Ubuntu SMP PREEMPT Wed Dec 9 17:14:07 UTC 2020 aarch64 GNU/Linux
```

Container runtime is `crio 1.18.4`.

Running with only `NET_ADMIN` capabilities produces the following error:

```
...
Auto host IP: X.X.X.X
+ echo 'Auto host IP: X.X.X.X
+ wait 19
+ /usr/sbin/ucarp '--interface=eth0' '--srcip=X.X.X.X' '--vhid=10' '--pass=...' '--addr=X.X.X.Y' '--upscript=/etc/ucarp/vip-up-default.sh' '--downscript=/etc/ucarp/vip-down-default.sh' '--xparam=16'

[ERROR] Unable to open raw device: [Operation not permitted]
[ERROR] Unable to find MAC address of [eth0]
```

However running with `NET_ADMIN` and `NET_RAW` works as expected.